### PR TITLE
Release model 2.1.0

### DIFF
--- a/packages/model/package.json
+++ b/packages/model/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tsim/model",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "dependencies": {
     "es-toolkit": "^1.49.0"
   }


### PR DESCRIPTION
## Summary
- Bump `@tsim/model` to 2.1.0
- Includes the es-toolkit swap (replacing lodash), validation logic refinements + expanded test coverage, and updated README documentation merged since 2.0.0

## Test plan
- [ ] CI passes (build, lint, test)
- [ ] npm publish after merge